### PR TITLE
Change the Vegas SDK link to one that actually works.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Sample OFX plugins from the Sony Vegas SDK, ported to OSX and Linux
 
 These plugins were adapted to compile and work on Linux and OSX.
 
-The Sony Vegas SDK has to be downloaded separately, due to its license, from [here](http://download.sonymediasoftware.com/dev/video_plugin_kit_ofx.zip).
+The Sony Vegas SDK has to be downloaded separately, due to its license, download "Video Plug-In Development Kit (OFX)" from [here](https://web.archive.org/web/20140122213530/http://www.sonycreativesoftware.com/download/devkits).
 The file, named `video_plugin_kit_OFX.zip`, should be put in this directory.
 
 To compile the debug version of these plugins, type "make BITS=32" for the 32-bits version,


### PR DESCRIPTION
Uses Waybackmachine to get a previous version of the Sony Creative Software downloads page.